### PR TITLE
fix: SkipNight need player incorrect

### DIFF
--- a/src/main/java/ml/windleaf/wlkitsreforged/plugins/SkipNight.kt
+++ b/src/main/java/ml/windleaf/wlkitsreforged/plugins/SkipNight.kt
@@ -32,21 +32,45 @@ class SkipNight : Plugin, Listener {
             && (e.player.world.time >= 12010 || e.player.world.isThundering)
             && Util.hasPermission(e.player, "skipnight", PermissionType.ACTION)
         ) {
-            if (!onBed.contains(e.player)) onBed.add(e.player)
             val percent = Util.getPluginConfig(name, "percent") as Int
-            if (percent < 0 || percent > 100)
+            if (percent < 0 || percent > 100) {
                 WLKits.log("&c错误: 配置文件中 &6plugins.skipnight.percent &c数值小于 0 或大于 100, 请重新进行配置!")
-            else {
-                if ((onBed.size / Bukkit.getOnlinePlayers().size) >= (percent / 100)) {
-                    Util.broadcastPlayers(Util.getPluginMsg(name, "msg-ok"))
-                    val world: World = e.player.world
-                    world.time = 100
-                } else {
-                    var fakePlayers = 0
-                    while ((fakePlayers / Bukkit.getOnlinePlayers().size) < (percent / 100)) fakePlayers += 1
-                    Util.broadcastPlayers(Util.insert(Util.getPluginMsg(name, "msg-need"), "onBed" to onBed.size.toString(), "needPlayers" to fakePlayers.toString()))
-                }
+                return
             }
+
+            if (!onBed.contains(e.player)) onBed.add(e.player)
+
+            val online = Bukkit.getOnlinePlayers().size
+
+            val onBedPercent = onBed.size / online
+
+            if (onBedPercent >= (percent / 100)) {
+                Util.broadcastPlayers(Util.getPluginMsg(name, "msg-ok"))
+                // 设置世界时间
+                e.player.world.time = 100
+                return
+            }
+
+            val offBed = online - onBed.size
+            // assume another N player is entered bed
+            var need = 1
+
+            while (need < offBed) {
+                val expect = (onBed.size + need) / online
+                if (expect >= (percent / 100)) {
+                    break
+                }
+                need++
+            }
+
+            Util.broadcastPlayers(
+                Util.insert(
+                    Util.getPluginMsg(name, "msg-need"),
+                    "onBed" to onBed.size.toString(),
+                    "needPlayers" to need.toString()
+                )
+            )
+
         }
     }
 


### PR DESCRIPTION
# Fix
> 修复 `SkipNight` 提示所需玩家数大于在线人数

```kotlin
var fakePlayers = 0
while ((fakePlayers / Bukkit.getOnlinePlayers().size) < (percent / 100)) fakePlayers += 1
Util.broadcastPlayers(Util.insert(Util.getPluginMsg(name, "msg-need"), "onBed" to onBed.size.toString(), "needPlayers" to fakePlayers.toString()))
```

> `fakePlayers / Bukkit.getOnlinePlayers().size` 应该为 `fakePlayers / (Bukkit.getOnlinePlayers().size - onBed.size)`